### PR TITLE
FIX: Using stringy type for strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "ARTISANCF",
+        "cooldown",
         "Darrion",
         "gitmon",
         "pnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "artisan_platform"
-version = "1.4.4"
+version = "1.4.6"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "dusa_collection_utils"
-version = "2.5.3"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cdf9fddbbff58e8eeecab3e3774f33da84e098b9aacd10dab30eabed46c937"
+checksum = "e432ffa01768fd7a920d17121f1428088558db3e3b94ba304695675f1e933db6"
 dependencies = [
  "block-modes",
  "cfg_rust_features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artisan_platform"
-version = "1.4.4"
+version = "1.4.6"
 edition = "2021"
 authors = [
     "Artisan Hosting",
@@ -40,7 +40,7 @@ users = "0.9.0"
 
 # Custom libraries
 recs_lib = "2.5.2"
-dusa_collection_utils = "2.5.3"
+dusa_collection_utils = "2.6.3"
 dusa = "1.2.2"
 
 # Logging

--- a/src/aggregator/aggregator.rs
+++ b/src/aggregator/aggregator.rs
@@ -1,15 +1,16 @@
 use ais_common::common::{
-    current_timestamp, AppName, AppStatus, GeneralMessage, MessageType, QueryMessage,
+    AppName, AppStatus, GeneralMessage, MessageType, QueryMessage,
     QueryResponse, QueryType, Status,
 };
 use ais_common::log::{log, Names};
 use ais_common::mailing::{Email, EmailSecure};
 use ais_common::messages::{receive_message, send_acknowledge, send_message};
 use ais_common::socket::get_socket_path;
-use ais_common::system::get_machine_id;
+use ais_common::system::{current_timestamp, get_machine_id};
 use ais_common::version::Version;
 use dusa_collection_utils::errors::{ErrorArray, ErrorArrayItem, UnifiedResult, WarningArray};
 use dusa_collection_utils::rwarc::LockWithTimeout;
+use dusa_collection_utils::stringy::Stringy;
 use dusa_collection_utils::types::PathType;
 use simple_pretty::warn;
 use std::collections::HashMap;
@@ -97,8 +98,8 @@ pub async fn handle_message(
                     }
                 }
                 MessageType::Acknowledgment => {
-                    let email: Email = Email { subject: format!("Connection dropped Erroneous communication"), 
-                body: format!("Machine: {} has dropped a connection due to non standard communication", get_machine_id()) };
+                    let email: Email = Email { subject: format!("Connection dropped Erroneous communication").into(), 
+                body: format!("Machine: {} has dropped a connection due to non standard communication", get_machine_id()).into() };
                     if let Err(err) = EmailSecure::new(email) {
                         ErrorArray::new(vec![err]).display(false);
                     };
@@ -255,12 +256,12 @@ pub async fn check_for_timeouts(state: LockWithTimeout<HashMap<AppName, Status>>
                     version: status.version.clone(),
                 };
                 let email = Email {
-                    subject: format!("Application timed out"),
+                    subject: format!("Application timed out").into(),
                     body: format!(
                         "The application {:?} on host {} has timed out",
                         app_name,
                         get_machine_id()
-                    ),
+                    ).into(),
                 };
                 let result = match EmailSecure::new(email) {
                     Ok(d) => d.send(),
@@ -275,8 +276,8 @@ pub async fn check_for_timeouts(state: LockWithTimeout<HashMap<AppName, Status>>
 }
 
 fn notify_status(name: &AppName, status: &AppStatus) -> Result<(), ErrorArrayItem> {
-    let subject: String = format!("Machine update: {}", get_machine_id());
-    let body: String = format!("The application: {:?} has change to {:?}", name, status);
+    let subject: Stringy = format!("Machine update: {}", get_machine_id()).into();
+    let body: Stringy = format!("The application: {:?} has change to {:?}", name, status).into();
     let email: Email = Email { subject, body };
     let secure_email: EmailSecure = EmailSecure::new(email)?;
     secure_email.send()?;
@@ -285,7 +286,7 @@ fn notify_status(name: &AppName, status: &AppStatus) -> Result<(), ErrorArrayIte
 
 #[cfg(test)]
 mod tests {
-    use ais_common::common::{current_timestamp, AppName, AppStatus, Status};
+    use ais_common::common::{AppName, AppStatus, Status};
 
     use super::*;
 

--- a/src/cli/git_credentials.rs
+++ b/src/cli/git_credentials.rs
@@ -1,15 +1,16 @@
 use std::io::{self, Write};
 
 use ais_common::git_data::{GitAuth, GitCredentials};
+use dusa_collection_utils::stringy::Stringy;
 use simple_pretty::{halt, pass};
 
-fn prompt_input(prompt: &str) -> String {
+fn prompt_input(prompt: &str) -> Stringy {
     print!("{}", prompt);
     io::stdout().flush().unwrap();
 
     let mut input = String::new();
     io::stdin().read_line(&mut input).unwrap();
-    input.trim().to_string()
+    input.trim().into()
 }
 
 fn main() {
@@ -22,15 +23,15 @@ fn main() {
     for i in 0..num_instances {
         println!("Enter details for GitAuth instance {}", i + 1);
 
-        let user = prompt_input("User: ");
-        let repo = prompt_input("Repo: ");
-        let branch = prompt_input("Branch: ");
+        let user: Stringy = prompt_input("User: ");
+        let repo: Stringy = prompt_input("Repo: ");
+        let branch: Stringy = prompt_input("Branch: ");
 
         let auth = GitAuth {
             user,
             repo,
             branch,
-            token: "******".to_owned(),
+            token: Stringy::new("******"),
         };
 
         git_creds.add_auth(auth);

--- a/src/common/lib/common.rs
+++ b/src/common/lib/common.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use dusa_collection_utils::stringy::Stringy;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -19,7 +20,7 @@ pub struct QueryMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QueryResponse {
-    pub version: String,
+    pub version: Stringy,
     pub app_status: Option<Status>,
     pub all_statuses: Option<HashMap<AppName, Status>>, // New field for all statuses
 }
@@ -34,10 +35,10 @@ pub enum MessageType {
 /// General structure for messages
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GeneralMessage {
-    pub version: String,
+    pub version: Stringy,
     pub msg_type: MessageType,
     pub payload: serde_json::Value,
-    pub error: Option<String>, // Simplified for this example
+    pub error: Option<Stringy>, // Simplified for this example
 }
 
 /// Enum representing the status of an application.
@@ -67,42 +68,5 @@ pub struct Status {
     pub app_name: AppName,
     pub app_status: AppStatus,
     pub timestamp: u64,
-    pub version: String, // Add version field
-}
-
-/// Retrieves the current Unix timestamp in seconds.
-pub fn current_timestamp() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let start = SystemTime::now();
-    let since_the_epoch = start
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards");
-    since_the_epoch.as_secs()
-}
-
-/// Converts a Unix timestamp to a human-readable string.
-pub fn format_unix_timestamp(timestamp: u64) -> String {
-    let duration = Duration::from_secs(timestamp);
-    let datetime = UNIX_EPOCH + duration;
-    let now = SystemTime::now();
-
-    if let Ok(elapsed) = now.duration_since(datetime) {
-        let seconds = elapsed.as_secs();
-        format!(
-            "{:02}:{:02}:{:02}",
-            seconds / 3600,
-            (seconds % 3600) / 60,
-            seconds % 60
-        )
-    } else if let Ok(elapsed) = datetime.duration_since(now) {
-        let seconds = elapsed.as_secs();
-        format!(
-            "-{:02}:{:02}:{:02}",
-            seconds / 3600,
-            (seconds % 3600) / 60,
-            seconds % 60
-        )
-    } else {
-        "Error in computing time".to_string()
-    }
+    pub version: Stringy, // Add version field
 }

--- a/src/common/lib/common.rs
+++ b/src/common/lib/common.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use dusa_collection_utils::stringy::Stringy;

--- a/src/common/lib/directive.rs
+++ b/src/common/lib/directive.rs
@@ -1,5 +1,6 @@
 use dusa_collection_utils::errors::ErrorArrayItem;
 use dusa_collection_utils::functions::open_file;
+use dusa_collection_utils::stringy::Stringy;
 use dusa_collection_utils::types::PathType;
 use serde::{Deserialize, Serialize};
 use std::io;
@@ -41,7 +42,7 @@ pub async fn parse_directive(path: &Path) -> Result<Directive, ErrorArrayItem> {
 }
 
 /// Reads a JSON file and removes lines starting with `#`
-fn read_json_without_comments(file_path: PathType) -> Result<String, ErrorArrayItem> {
+fn read_json_without_comments(file_path: PathType) -> Result<Stringy, ErrorArrayItem> {
     let file = open_file(file_path, false)?;
     let reader = io::BufReader::new(file);
 
@@ -56,5 +57,5 @@ fn read_json_without_comments(file_path: PathType) -> Result<String, ErrorArrayI
         }
     }
 
-    Ok(json_string)
+    Ok(Stringy::new(&json_string))
 }

--- a/src/common/lib/dusa_wrapper.rs
+++ b/src/common/lib/dusa_wrapper.rs
@@ -1,19 +1,19 @@
-use dusa_collection_utils::errors::ErrorArrayItem;
+use dusa_collection_utils::{errors::ErrorArrayItem, stringy::Stringy};
 
 use crate::dusa::run;
 
-pub fn encrypt_text(data: String) -> Result<String, ErrorArrayItem> {
+pub fn encrypt_text(data: Stringy) -> Result<Stringy, ErrorArrayItem> {
     match run(
         crate::dusa::ProgramMode::EncryptText,
         None,
         None,
         None,
-        Some(data),
+        Some(data.to_string()),
     )
     .uf_unwrap()
     {
         Ok(d) => match d {
-            Some(d) => Ok(d),
+            Some(d) => Ok(Stringy::new(&d)),
             None => {
                 return Err(ErrorArrayItem::new(
                     dusa_collection_utils::errors::Errors::GeneralError,
@@ -25,18 +25,18 @@ pub fn encrypt_text(data: String) -> Result<String, ErrorArrayItem> {
     }
 }
 
-pub fn decrypt_text(data: String) -> Result<String, ErrorArrayItem> {
+pub fn decrypt_text(data: Stringy) -> Result<Stringy, ErrorArrayItem> {
     match run(
         crate::dusa::ProgramMode::DecryptText,
         None,
         None,
         None,
-        Some(data),
+        Some(data.to_string()),
     )
     .uf_unwrap()
     {
         Ok(d) => match d {
-            Some(d) => Ok(d),
+            Some(d) => Ok(Stringy::new(&d)),
             None => {
                 return Err(ErrorArrayItem::new(
                     dusa_collection_utils::errors::Errors::GeneralError,

--- a/src/common/lib/git.rs
+++ b/src/common/lib/git.rs
@@ -1,8 +1,7 @@
 use std::{env, future::Future, pin::Pin, process::Output};
 
 use dusa_collection_utils::{
-    errors::{ErrorArrayItem, Errors},
-    types::{ClonePath, PathType},
+    errors::{ErrorArrayItem, Errors}, stringy::Stringy, types::{ClonePath, PathType}
 };
 use tokio::process::Command;
 
@@ -29,13 +28,13 @@ async fn check_git_installed() -> Result<(), ErrorArrayItem> {
 #[derive(Debug)]
 pub enum GitAction {
     Clone {
-        repo_name: String,
-        repo_owner: String,
+        repo_name: Stringy,
+        repo_owner: Stringy,
         destination: PathType,
-        repo_branch: String,
+        repo_branch: Stringy,
     },
     Pull {
-        target_branch: String,
+        target_branch: Stringy,
         destination: PathType,
     },
     Push {
@@ -47,11 +46,11 @@ pub enum GitAction {
     },
     Commit {
         directory: PathType,
-        message: String,
+        message: Stringy,
     },
     CheckRemoteAhead(PathType),
     Switch {
-        branch: String,
+        branch: Stringy,
         destination: PathType,
     },
     // git config --global --add safe.directory /var/www/current/path

--- a/src/common/lib/git_data.rs
+++ b/src/common/lib/git_data.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::ARTISANCF,
     dusa_wrapper::{decrypt_text, encrypt_text},
 };
-use dusa_collection_utils::errors::ErrorArrayItem;
+use dusa_collection_utils::{errors::ErrorArrayItem, stringy::Stringy};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
@@ -16,16 +16,16 @@ pub struct GitCredentials {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GitAuth {
-    pub user: String,
-    pub repo: String,
-    pub branch: String,
-    pub token: String, // TODO REMOVE LATER
+    pub user: Stringy,
+    pub repo: Stringy,
+    pub branch: Stringy,
+    pub token: Stringy, // TODO REMOVE LATER
 }
 
 // TODO ensure we are creating an Array of GitAuth items to parse in loops
 impl GitCredentials {
     pub fn new() -> Result<Self, ErrorArrayItem> {
-        let encrypted_credentials = Self::read_file(ARTISANCF)?;
+        let encrypted_credentials: Stringy = Stringy::new(&Self::read_file(ARTISANCF)?);
 
         let decrypted_string = decrypt_text(encrypted_credentials)?.replace("\n", "");
 
@@ -46,7 +46,7 @@ impl GitCredentials {
 
     pub fn save(&self, file_path: &str) -> Result<(), ErrorArrayItem> {
         // Serialize GitCredentials to JSON
-        let json_data = serde_json::to_string(self)?;
+        let json_data = Stringy::new(&serde_json::to_string(self)?);
 
         // Encrypt the JSON data
         let encrypted_data = encrypt_text(json_data)?;

--- a/src/common/lib/git_data.rs
+++ b/src/common/lib/git_data.rs
@@ -19,7 +19,7 @@ pub struct GitAuth {
     pub user: String,
     pub repo: String,
     pub branch: String,
-    pub token: String,
+    pub token: String, // TODO REMOVE LATER
 }
 
 // TODO ensure we are creating an Array of GitAuth items to parse in loops

--- a/src/common/lib/mailing.rs
+++ b/src/common/lib/mailing.rs
@@ -55,7 +55,7 @@ impl EmailSecure {
         }
 
         let plain_email_data: Stringy = Stringy::from_string(format!("{}-=-{}", email.subject, email.body));
-        let encrypted_data: Stringy = encrypt_text(plain_email_data.to_string()).map(|d| Stringy::from_string(d))?;
+        let encrypted_data: Stringy = encrypt_text(plain_email_data)?;
 
         Ok(EmailSecure {
             data: encrypted_data,

--- a/src/common/lib/mailing.rs
+++ b/src/common/lib/mailing.rs
@@ -1,5 +1,5 @@
 use crate::dusa_wrapper::encrypt_text;
-use dusa_collection_utils::errors::{ErrorArrayItem, Errors};
+use dusa_collection_utils::{errors::{ErrorArrayItem, Errors}, stringy::Stringy};
 use serde::{Deserialize, Serialize};
 use std::{fmt, io::Write, net::TcpStream};
 
@@ -7,16 +7,16 @@ use std::{fmt, io::Write, net::TcpStream};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Email {
     /// The subject of the email.
-    pub subject: String,
+    pub subject: Stringy,
     /// The body of the email.
-    pub body: String,
+    pub body: Stringy,
 }
 
 /// Represents an encrypted email message.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EmailSecure {
     /// The encrypted email data.
-    pub data: String,
+    pub data: Stringy,
 }
 
 // Display implementations
@@ -34,7 +34,7 @@ impl fmt::Display for EmailSecure {
 
 impl Email {
     /// Creates a new Email instance with the given subject and body.
-    pub fn new(subject: String, body: String) -> Self {
+    pub fn new(subject: Stringy, body: Stringy) -> Self {
         Email { subject, body }
     }
 
@@ -54,8 +54,8 @@ impl EmailSecure {
             ));
         }
 
-        let plain_email_data: String = format!("{}-=-{}", email.subject, email.body);
-        let encrypted_data: String = encrypt_text(plain_email_data)?;
+        let plain_email_data: Stringy = Stringy::from_string(format!("{}-=-{}", email.subject, email.body));
+        let encrypted_data: Stringy = encrypt_text(plain_email_data.to_string()).map(|d| Stringy::from_string(d))?;
 
         Ok(EmailSecure {
             data: encrypted_data,

--- a/src/common/lib/manager.rs
+++ b/src/common/lib/manager.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use dusa_collection_utils::stringy::Stringy;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -19,7 +20,7 @@ pub enum NetworkRequestType {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NetworkResponse {
     pub status: String,
-    pub data: Option<String>,
+    pub data: Option<Stringy>,
 }
 
 impl fmt::Display for NetworkResponse {
@@ -34,10 +35,3 @@ impl fmt::Display for NetworkResponse {
         Ok(())
     }
 }
-
-// let response_data = response.data.unwrap();
-// let warning_applications: Vec<_> = response_data
-//     .lines()
-//     .filter(|line| line.contains("Warning"))
-//     .collect();
-//

--- a/src/common/lib/node.rs
+++ b/src/common/lib/node.rs
@@ -3,14 +3,14 @@ use std::{
     process::{Command, ExitStatus},
 };
 
-use dusa_collection_utils::{errors::ErrorArrayItem, types::PathType};
+use dusa_collection_utils::{errors::ErrorArrayItem, stringy::Stringy, types::PathType};
 
 /// Function to create a systemd service file dynamically
 pub fn create_node_systemd_service(
     exec_start: &str,
     working_dir: &PathType,
     description: &str,
-) -> Result<String, ErrorArrayItem> {
+) -> Result<Stringy, ErrorArrayItem> {
     // Setting environmental variables depending on the directive file
     let service_file_content = format!(
         r#"[Unit]
@@ -35,7 +35,7 @@ WantedBy=multi-user.target
         description, exec_start, working_dir
     );
 
-    Ok(service_file_content)
+    Ok(Stringy::new(&service_file_content))
 }
 
 pub fn run_npm_install(working_dir: &PathType) -> io::Result<ExitStatus> {

--- a/src/common/lib/system.rs
+++ b/src/common/lib/system.rs
@@ -1,6 +1,6 @@
 use dusa_collection_utils::{errors::{ErrorArray, ErrorArrayItem}, stringy::Stringy};
 use gethostname::gethostname;
-use std::{collections::HashMap, fs, path::Path, time::{Duration, SystemTime, UNIX_EPOCH}};
+use std::{collections::HashMap, fs, io::{self, Write}, path::Path, time::{Duration, SystemTime, UNIX_EPOCH}};
 use sysinfo::System;
 use uuid::Uuid;
 
@@ -94,4 +94,13 @@ pub fn format_unix_timestamp(timestamp: u64) -> Stringy {
     };
 
     return Stringy::from_string(data)
+}
+
+pub fn prompt_input(prompt: &str) -> Stringy {
+    print!("{}", prompt);
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    Stringy::new(input.trim())
 }

--- a/src/common/lib/system.rs
+++ b/src/common/lib/system.rs
@@ -1,50 +1,97 @@
+use dusa_collection_utils::{errors::{ErrorArray, ErrorArrayItem}, stringy::Stringy};
 use gethostname::gethostname;
-use std::{collections::HashMap, fs, path::Path};
+use std::{collections::HashMap, fs, path::Path, time::{Duration, SystemTime, UNIX_EPOCH}};
 use sysinfo::System;
 use uuid::Uuid;
 
 pub const MACHINE_ID_FILE: &str = "/etc/artisan_id";
 
-pub fn get_system_stats() -> HashMap<String, String> {
+pub fn get_system_stats() -> HashMap<Stringy, Stringy> {
     let mut system = System::new_all();
     system.refresh_all();
 
-    let mut stats = HashMap::new();
+    let mut stats: HashMap<Stringy, Stringy> = HashMap::new();
     stats.insert(
-        "CPU Usage".to_string(),
-        format!("{:.2}%", system.global_cpu_info().cpu_usage()),
+        Stringy::new("CPU Usage"),
+        Stringy::from_string(format!("{:.2}%", system.global_cpu_info().cpu_usage())),
     );
     stats.insert(
-        "Total RAM".to_string(),
-        format!("{} MB", system.total_memory() / 1024),
+        Stringy::new("Total RAM"),
+        Stringy::from_string(format!("{} MB", system.total_memory() / 1024)),
     );
     stats.insert(
-        "Used RAM".to_string(),
-        format!("{} MB", system.used_memory() / 1024),
+        Stringy::new("Used RAM"),
+        Stringy::from(format!("{} MB", system.used_memory() / 1024)),
     );
     stats.insert(
-        "Total Swap".to_string(),
-        format!("{} MB", system.total_swap() / 1024),
+        Stringy::new("Total Swap"),
+        Stringy::from_string(format!("{} MB", system.total_swap() / 1024)),
     );
     stats.insert(
-        "Used Swap".to_string(),
-        format!("{} MB", system.used_swap() / 1024),
+        Stringy::new("Used Swap"),
+        Stringy::from_string(format!("{} MB", system.used_swap() / 1024)),
     );
-    stats.insert("Hostname".to_string(), format!("{:?}", gethostname()));
+    stats.insert(Stringy::new("Hostname"), Stringy::from_string(format!("{:?}", gethostname())));
 
     stats
 }
 
-pub fn get_machine_id() -> String {
+pub fn get_machine_id() -> Stringy {
     if Path::new(MACHINE_ID_FILE).exists() {
-        fs::read_to_string(MACHINE_ID_FILE).unwrap_or_else(|_| generate_machine_id())
+        match fs::read_to_string(MACHINE_ID_FILE) {
+            Ok(d) => Stringy::from_string(d),
+            Err(e) => {
+                ErrorArray::new(vec![ErrorArrayItem::from(e)]).display(false);
+                generate_machine_id()
+            }
+        }
     } else {
         generate_machine_id()
     }
 }
 
-pub fn generate_machine_id() -> String {
+pub fn generate_machine_id() -> Stringy {
     let id = Uuid::new_v4().to_string();
     fs::write(MACHINE_ID_FILE, &id).expect("Unable to write machine ID file");
-    id
+    Stringy::from_string(id)
+}
+
+
+/// Retrieves the current Unix timestamp in seconds.
+pub fn current_timestamp() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let start = SystemTime::now();
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    since_the_epoch.as_secs()
+}
+
+/// Converts a Unix timestamp to a human-readable string.
+pub fn format_unix_timestamp(timestamp: u64) -> Stringy {
+    let duration: Duration = Duration::from_secs(timestamp);
+    let datetime: SystemTime = UNIX_EPOCH + duration;
+    let now: SystemTime = SystemTime::now();
+
+    let data = if let Ok(elapsed) = now.duration_since(datetime) {
+        let seconds = elapsed.as_secs();
+        format!(
+            "{:02}:{:02}:{:02}",
+            seconds / 3600,
+            (seconds % 3600) / 60,
+            seconds % 60
+        )
+    } else if let Ok(elapsed) = datetime.duration_since(now) {
+        let seconds = elapsed.as_secs();
+        format!(
+            "-{:02}:{:02}:{:02}",
+            seconds / 3600,
+            (seconds % 3600) / 60,
+            seconds % 60
+        )
+    } else {
+        "Error in computing time".to_string()
+    };
+
+    return Stringy::from_string(data)
 }

--- a/src/directive/main.rs
+++ b/src/directive/main.rs
@@ -4,14 +4,7 @@
 // We save two hashes to ensure we aren't changing thing when they arent needed. We save a hash before copy. and we save a hash that we modify.
 
 use ais_common::{
-    apache::{create_apache_config, reload_apache},
-    common::{current_timestamp, AppName, AppStatus, Status},
-    directive::{parse_directive, scan_directories},
-    messages::report_status,
-    monitor::{create_monitoring_script, create_monitoring_service, MONITOR_DIR},
-    node::{create_node_systemd_service, run_npm_install},
-    systemd::{enable_now, reload_systemd_daemon},
-    version::Version,
+    apache::{create_apache_config, reload_apache}, common::{AppName, AppStatus, Status}, directive::{parse_directive, scan_directories}, messages::report_status, monitor::{create_monitoring_script, create_monitoring_service, MONITOR_DIR}, node::{create_node_systemd_service, run_npm_install}, system::current_timestamp, systemd::{enable_now, reload_systemd_daemon}, version::Version
 };
 use dusa_collection_utils::{
     errors::{ErrorArray, ErrorArrayItem},

--- a/src/github/main.rs
+++ b/src/github/main.rs
@@ -1,10 +1,11 @@
 use std::pin::Pin;
 
-use ais_common::common::{current_timestamp, AppName, AppStatus, Status};
+use ais_common::common::{AppName, AppStatus, Status};
 use ais_common::git::GitAction;
 use ais_common::git_data::{GitAuth, GitCredentials};
 use ais_common::messages::report_status;
 use ais_common::setcap::{get_id, set_file_ownership, SystemUsers};
+use ais_common::system::current_timestamp;
 use ais_common::systemd::restart_if_exists;
 use ais_common::version::Version;
 use dusa_collection_utils::errors::{ErrorArray, ErrorArrayItem, Errors};

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -2,16 +2,16 @@ use ais_common::{
     mailing::{Email, EmailSecure},
     version::Version,
 };
-use dusa_collection_utils::errors::ErrorArray;
+use dusa_collection_utils::{errors::ErrorArray, stringy::Stringy};
 
 // Simple mailer test
 fn main() {
     let email_data = Email {
-        subject: String::from("Emailing system test"),
+        subject: Stringy::from("Emailing system test"),
         body: format!(
             "This is a test of the updated email system on ais platform: {}",
             Version::get()
-        ),
+        ).into(),
     };
     let email_secure = EmailSecure::new(email_data);
     match email_secure {

--- a/src/manager/server/main.rs
+++ b/src/manager/server/main.rs
@@ -10,6 +10,7 @@ use ais_common::socket::get_socket_path;
 use ais_common::system::{get_machine_id, get_system_stats};
 use ais_common::version::Version;
 use dusa_collection_utils::errors::{ErrorArray, ErrorArrayItem, WarningArray};
+use dusa_collection_utils::stringy::Stringy;
 use network::start_server;
 use simple_pretty::warn;
 use std::collections::HashMap;
@@ -38,12 +39,12 @@ async fn main() -> Result<(), ErrorArrayItem> {
                 Err(e) => {
                     warn("Aggregator is unresponsive, Calling for backup");
                     let email = Email {
-                        subject: format!("{}", machine_id),
+                        subject: format!("{}", machine_id).into(),
                         body: format!(
                             "The aggregator on system: {}. Is not running 
                     or unreachable and systemd was unable the rectify the issue: {}",
                             machine_id, e
-                        ),
+                        ).into(),
                     };
                     let _ = EmailSecure::new(email)
                         .inspect_err(|err| ErrorArray::new(vec![err.clone()]).display(false))
@@ -121,9 +122,9 @@ async fn update_git_config(new_auth: Vec<GitAuth>) -> Result<(), ErrorArrayItem>
     new_git_data.save(ARTISANCF)
 }
 
-async fn query_git_config() -> Result<HashMap<String, GitAuth>, ErrorArrayItem> {
+async fn query_git_config() -> Result<HashMap<Stringy, GitAuth>, ErrorArrayItem> {
     let git_credentials: Vec<GitAuth> = GitCredentials::new_vec()?;
-    let mut git_hashmap: HashMap<String, GitAuth> = HashMap::new();
+    let mut git_hashmap: HashMap<Stringy, GitAuth> = HashMap::new();
 
     for git_item in git_credentials {
         let name = git_item.clone().repo;

--- a/src/manager/server/network.rs
+++ b/src/manager/server/network.rs
@@ -2,6 +2,7 @@ use ais_common::constants::SERVERADDRESS;
 use ais_common::manager::{NetworkRequest, NetworkRequestType, NetworkResponse};
 use ais_common::system::get_system_stats;
 use dusa_collection_utils::errors::ErrorArrayItem;
+use dusa_collection_utils::stringy::Stringy;
 use systemctl::Unit;
 // network.rs
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -29,7 +30,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                             eprintln!("Failed to parse request: {}", e);
                             let response = NetworkResponse {
                                 status: String::from("Error"),
-                                data: Some(String::from("Invalid request format")),
+                                data: Some(Stringy::new("Invalid request format")),
                             };
                             let response = serde_json::to_string(&response).unwrap();
                             let _ = socket.write_all(response.as_bytes()).await;
@@ -42,7 +43,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                             Ok(statuses) => {
                                 let response = NetworkResponse {
                                     status: String::from("Success"),
-                                    data: Some(serde_json::to_string(&statuses).unwrap()),
+                                    data: Some(Stringy::new(&serde_json::to_string(&statuses).unwrap())),
                                 };
                                 let response = serde_json::to_string(&response).unwrap();
                                 let _ = socket.write_all(response.as_bytes()).await;
@@ -51,7 +52,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                                 eprintln!("Failed to query aggregator: {}", e);
                                 let response = NetworkResponse {
                                     status: String::from("Error"),
-                                    data: Some(String::from("Failed to query aggregator")),
+                                    data: Some(Stringy::new("Failed to query aggregator")),
                                 };
                                 let response = serde_json::to_string(&response).unwrap();
                                 let _ = socket.write_all(response.as_bytes()).await;
@@ -65,7 +66,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                                             eprintln!("Failed to update Git config: {}", e);
                                             let response = NetworkResponse {
                                                 status: String::from("Error"),
-                                                data: Some(String::from(
+                                                data: Some(Stringy::new(
                                                     "Failed to update Git config",
                                                 )),
                                             };
@@ -91,7 +92,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                                         eprintln!("{:?}", data);
                                         let response = NetworkResponse {
                                             status: String::from("Error"),
-                                            data: Some(String::from("Invalid GitAuth data")),
+                                            data: Some(Stringy::new("Invalid GitAuth data")),
                                         };
                                         let response = serde_json::to_string(&response).unwrap();
                                         let _ = socket.write_all(response.as_bytes()).await;
@@ -100,7 +101,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                             } else {
                                 let response = NetworkResponse {
                                     status: String::from("Error"),
-                                    data: Some(String::from("No data provided")),
+                                    data: Some(Stringy::new("No data provided")),
                                 };
                                 let response = serde_json::to_string(&response).unwrap();
                                 let _ = socket.write_all(response.as_bytes()).await;
@@ -110,7 +111,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                             Ok(git_statuses) => {
                                 let response = NetworkResponse {
                                     status: String::from("Success"),
-                                    data: Some(serde_json::to_string(&git_statuses).unwrap()),
+                                    data: Some(Stringy::new(&serde_json::to_string(&git_statuses).unwrap())),
                                 };
                                 let response = serde_json::to_string(&response).unwrap();
                                 let _ = socket.write_all(response.as_bytes()).await;
@@ -119,7 +120,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                                 eprintln!("Failed to query Git config: {}", e);
                                 let response = NetworkResponse {
                                     status: String::from("Error"),
-                                    data: Some(String::from("Failed to query Git config")),
+                                    data: Some(Stringy::new("Failed to query Git config")),
                                 };
                                 let response = serde_json::to_string(&response).unwrap();
                                 let _ = socket.write_all(response.as_bytes()).await;
@@ -129,7 +130,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                             let data = get_system_stats();
                             let response = NetworkResponse {
                                 status: String::from("Success"),
-                                data: Some(serde_json::to_string(&data).unwrap()),
+                                data: Some(Stringy::new(&serde_json::to_string(&data).unwrap())),
                             };
                             let response = serde_json::to_string(&response).unwrap();
                             let _ = socket.write_all(response.as_bytes()).await;
@@ -137,7 +138,7 @@ pub async fn start_server() -> Result<(), ErrorArrayItem> {
                         _ => {
                             let response = NetworkResponse {
                                 status: String::from("Error"),
-                                data: Some(String::from("Unknown request type")),
+                                data: Some(Stringy::from("Unknown request type")),
                             };
                             let response = serde_json::to_string(&response).unwrap();
                             let _ = socket.write_all(response.as_bytes()).await;

--- a/src/manager/tui/main.rs
+++ b/src/manager/tui/main.rs
@@ -13,10 +13,11 @@ use ais_common::{
     common::{AppName, AppStatus, Status},
     constants::SERVERPORT,
     git_data::{GitAuth, GitCredentials},
-    manager::{NetworkRequest, NetworkRequestType, NetworkResponse},
+    manager::{NetworkRequest, NetworkRequestType, NetworkResponse}, system::prompt_input,
 };
 use crossterm::event::{self, Event, KeyCode};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use dusa_collection_utils::stringy::Stringy;
 use tui::{
     backend::CrosstermBackend,
     layout::Alignment,
@@ -356,7 +357,7 @@ fn handle_git_repo_update(
             user,
             repo,
             branch,
-            token: "******".to_owned(),
+            token: Stringy::new("******"),
         };
 
         git_creds.add_auth(auth);
@@ -396,14 +397,6 @@ fn handle_git_repo_update(
     // Terminal will be redrawn in the main loop after the flag is reset
 }
 
-fn prompt_input(prompt: &str) -> String {
-    print!("{}", prompt);
-    io::stdout().flush().unwrap();
-
-    let mut input = String::new();
-    io::stdin().read_line(&mut input).unwrap();
-    input.trim().to_string()
-}
 
 fn update_data(
     ip_address: &str,

--- a/src/systemd/main.rs
+++ b/src/systemd/main.rs
@@ -1,5 +1,6 @@
-use ais_common::common::{current_timestamp, AppName, AppStatus, Status};
+use ais_common::common::{AppName, AppStatus, Status};
 use ais_common::messages::report_status;
+use ais_common::system::current_timestamp;
 use ais_common::systemd::{self, ProcessInfo, Services};
 use ais_common::version::Version;
 use rand::seq::SliceRandom;

--- a/src/tracking/main.rs
+++ b/src/tracking/main.rs
@@ -1,10 +1,12 @@
-use ais_common::common::{current_timestamp, AppName, AppStatus, Status};
+use ais_common::common::{AppName, AppStatus, Status};
 use ais_common::dusa_wrapper::encrypt_text;
 use ais_common::messages::report_status;
+use ais_common::system::current_timestamp;
 use ais_common::version::Version;
 use chrono::{DateTime, Local};
 use dusa_collection_utils::errors::{ErrorArray, WarningArray};
 use dusa_collection_utils::functions::del_file;
+use dusa_collection_utils::stringy::Stringy;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, BufReader, Write};
@@ -303,7 +305,7 @@ async fn store_summary(summaries: HashMap<String, SessionSummary>) -> io::Result
     all_summary_data.push_str("--------------------------------\n");
 
     // Encrypt and write the summary data to the final file
-    let encrypted_data = encrypt_text(all_summary_data).unwrap();
+    let encrypted_data = encrypt_text(Stringy::new(&all_summary_data)).unwrap();
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/welcome/main.rs
+++ b/src/welcome/main.rs
@@ -2,6 +2,7 @@ use ais_common::{
     system::{get_machine_id, get_system_stats},
     version::Version,
 };
+use dusa_collection_utils::stringy::Stringy;
 use lsb_release::LsbRelease;
 use simple_pretty::output;
 
@@ -10,12 +11,12 @@ fn main() {
     let lsb_failsafe: LsbRelease = LsbRelease {
         id: String::from("failsafe"),
         desc: String::from("System in a damaged state"),
-        version: Version::get(),
+        version: Version::get().to_string(),
         code_name: String::from("Wacky Whitfield"),
     };
 
     let ais_version: Version = Version::get_raw();
-    let ais_identyfi: String = get_machine_id();
+    let ais_identyfi: Stringy = get_machine_id();
     let system_version: LsbRelease = lsb_release::info().unwrap_or(lsb_failsafe);
     let system_hostname = gethostname::gethostname();
     // let (system_load_1, system_load_5, system_load_15) = match sys.load_average() {
@@ -60,7 +61,7 @@ supporting me and Artisan Hosting.
         // system_load_1,
         // system_load_5,
         // system_load_15,
-        system.get("Used RAM").unwrap_or(&"X.xx".to_owned())
+        system.get(&Stringy::new("Used RAM")).unwrap_or(&Stringy::new("X.xx"))
     );
 
     output("BLUE", &format!("{}", welcome_text));


### PR DESCRIPTION
for strings in structs that aren't mutated normally using the new type `Stringy` to allow for lower mem allocation and type level thread saftey. `THIS IS A BREAKING CHANGE VERSION HAS BEEN BUMPED ACCORDINGLY`